### PR TITLE
Hardening pass: autostart quoting, mutex reliability, lock and restore policies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,10 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
   test:
     name: Lint & Test (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Auto-Build Executables
+﻿name: Auto-Build Executables
 
 on:
   release:
@@ -21,6 +21,7 @@ jobs:
   build:
     name: Build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
     permissions:
       contents: read
     strategy:
@@ -117,6 +118,7 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: write

--- a/dnscrypt-proxy-gui.PY
+++ b/dnscrypt-proxy-gui.PY
@@ -154,8 +154,13 @@ def acquire_single_instance_lock():
     system = platform.system()
     if system == "Windows":
         import ctypes
-        mutex = ctypes.windll.kernel32.CreateMutexW(None, False, "Global\\" + APP_NAME)
-        if mutex and ctypes.windll.kernel32.GetLastError() == 183:  # ERROR_ALREADY_EXISTS
+        # GetLastError must be captured through ctypes' own machinery: a
+        # plain windll call can be preceded by other ctypes invocations
+        # that clobber the thread's last-error value.
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        ERROR_ALREADY_EXISTS = 183
+        mutex = kernel32.CreateMutexW(None, False, "Global\\" + APP_NAME)
+        if mutex and ctypes.get_last_error() == ERROR_ALREADY_EXISTS:
             return None
         return ("mutex", mutex)
     lock_path = os.path.join(tempfile.gettempdir(), f"{APP_NAME}.instance.lock")
@@ -492,14 +497,18 @@ class DNSCryptClientGUI:
     def restore_dns_backup(self):
         """Restore the exact pre-GUI DNS configuration.
 
-        Returns True when a backup existed and was applied. When no backup
-        exists this deliberately does nothing - it must never guess."""
+        Returns True when a backup existed and was fully applied. When no
+        backup exists this deliberately does nothing - it must never guess.
+        On PARTIAL failure the backup file is kept so Restore DNS can be
+        retried; callers must not fall back to reset-to-DHCP in that case
+        (see _revert_after_restore_attempt)."""
         try:
             with open(self.dns_backup_file, "r", encoding="utf-8") as fh:
                 payload = json.load(fh)
         except FileNotFoundError:
             return False
         except Exception:
+            LOG.warning("Corrupt DNS backup at %s", self.dns_backup_file, exc_info=True)
             return False  # corrupt backup: caller decides on fallback policy
         system = platform.system()
         if payload.get("platform") != system:
@@ -512,6 +521,12 @@ class DNSCryptClientGUI:
             failures = self._restore_dns_linux(payload)
         else:
             failures = []
+        if failures:
+            LOG.warning(
+                "DNS restore incomplete for: %s - keeping %s for retry",
+                ", ".join(failures), self.dns_backup_file,
+            )
+            return False
         try:
             os.remove(self.dns_backup_file)
         except OSError:
@@ -959,10 +974,30 @@ class DNSCryptClientGUI:
             if self.tray_icon: self.tray_icon.stop()
         self._post_ui(self.root.destroy)
 
-    def get_startup_path_and_command(self):
-        script_path = os.path.abspath(sys.argv[0])
-        command = f'"{sys.executable}" "{script_path}"'
-        return script_path, command
+    @staticmethod
+    def _xml_escape(text):
+        return (text.replace("&", "&amp;")
+                    .replace("<", "&lt;")
+                    .replace(">", "&gt;"))
+
+    @staticmethod
+    def _desktop_quote(token):
+        """Quote a token for a .desktop Exec= line.
+
+        Inside double quotes the spec only treats \\" and \\\\ specially;
+        %% escapes what would otherwise parse as a field code."""
+        escaped = token.replace("\\", "\\\\").replace('"', '\\"').replace("%", "%%")
+        return f'"{escaped}"'
+
+    def get_startup_tokens(self):
+        """Argument tokens that relaunch this app for autostart entries.
+
+        Frozen builds must launch the executable itself - registering it
+        twice ('exe exe') used to work by accident but is wrong; script
+        runs need the interpreter plus the script path."""
+        if getattr(sys, "frozen", False):
+            return [sys.executable]
+        return [sys.executable, os.path.abspath(sys.argv[0])]
 
     def toggle_startup(self):
         if self.startup_var.get(): self.add_to_startup()
@@ -970,9 +1005,9 @@ class DNSCryptClientGUI:
 
     def add_to_startup(self):
         system = platform.system()
-        _, command = self.get_startup_path_and_command()
         try:
             if system == "Windows":
+                command = " ".join(f'"{t}"' for t in self.get_startup_tokens())
                 key_path = r"Software\Microsoft\Windows\CurrentVersion\Run"
                 with winreg.OpenKey(winreg.HKEY_CURRENT_USER, key_path, 0, winreg.KEY_SET_VALUE) as key:
                     winreg.SetValueEx(key, APP_NAME, 0, winreg.REG_SZ, command)
@@ -980,15 +1015,19 @@ class DNSCryptClientGUI:
                 autostart_path = os.path.expanduser("~/.config/autostart")
                 os.makedirs(autostart_path, exist_ok=True)
                 desktop_file_path = os.path.join(autostart_path, f"{APP_NAME}.desktop")
+                exec_line = " ".join(self._desktop_quote(t) for t in self.get_startup_tokens())
                 with open(desktop_file_path, "w") as f:
-                    f.write(f"[Desktop Entry]\nType=Application\nExec={command}\nX-GNOME-Autostart-enabled=true\nName={APP_NAME}\n")
+                    f.write(f"[Desktop Entry]\nType=Application\nExec={exec_line}\nX-GNOME-Autostart-enabled=true\nName={APP_NAME}\n")
             elif system == "Darwin":
                 agent_path = os.path.expanduser(f"~/Library/LaunchAgents/com.{APP_NAME}.plist")
+                args_xml = "".join(
+                    f"<string>{self._xml_escape(t)}</string>" for t in self.get_startup_tokens()
+                )
                 plist_content = f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0"><dict>
 <key>Label</key><string>com.{APP_NAME}</string>
-<key>ProgramArguments</key><array><string>{sys.executable}</string><string>{os.path.abspath(sys.argv[0])}</string></array>
+<key>ProgramArguments</key><array>{args_xml}</array>
 <key>RunAtLoad</key><true/>
 </dict></plist>"""
                 with open(agent_path, "w") as f: f.write(plist_content)
@@ -1118,14 +1157,20 @@ class DNSCryptClientGUI:
     def update_config_and_restart_proxy(self, event=None):
         self.save_settings()
         if self.active_server_info:
-            if not self.action_lock.acquire(blocking=False): return
             def task():
+                # Acquire and release on the same thread; a busy lock is
+                # reported instead of silently dropping the change.
+                if not self.action_lock.acquire(blocking=False):
+                    self.root.after(0, lambda: self.status_var.set(
+                        "Busy - configuration change will need to be re-applied."))
+                    return
                 try:
                     self.root.after(0, lambda: self.status_var.set("Configuration changed. Restarting proxy..."))
                     current_servers = self.active_server_info
                     self.deactivate_dns()
                     if not self.active_server_info: self.activate_dns(current_servers)
-                finally: self.action_lock.release()
+                finally:
+                    self.action_lock.release()
             threading.Thread(target=task, daemon=True).start()
 
     def open_bridge_selector(self):
@@ -1447,8 +1492,7 @@ class DNSCryptClientGUI:
             # Parent is gone - clean up before exiting ourselves.
             try:
                 if self.active_server_info:
-                    if not self.restore_dns_backup():
-                        self.revert_system_dns()
+                    self._revert_after_restore_attempt()
             except Exception:
                 pass
             _stop_proxy()
@@ -1536,7 +1580,7 @@ class DNSCryptClientGUI:
 
         if not success:
              update_ui('status', "Failed to set system DNS."); self.stop_proxy_only()
-             self.restore_dns_backup()
+             self._revert_after_restore_attempt()
              self.root.after(0, lambda: self.activate_button.config(state=tk.NORMAL))
              return
         
@@ -1565,8 +1609,7 @@ class DNSCryptClientGUI:
 
         # Exact restoration of the user's previous DNS configuration; the
         # reset-to-DHCP path is only a last resort when no backup exists.
-        if not self.restore_dns_backup():
-            self.revert_system_dns()
+        self._revert_after_restore_attempt()
         
         def final_ui_reset():
             self.active_server_info = []
@@ -1616,8 +1659,16 @@ class DNSCryptClientGUI:
         self.is_exiting = True
         if self.active_server_info:
             self.stop_proxy_only()
-            if not self.restore_dns_backup():
-                self.revert_system_dns()
+            self._revert_after_restore_attempt()
+
+    def _revert_after_restore_attempt(self):
+        """Restore the exact backup; reset-to-DHCP only as a true last resort.
+
+        A PARTIAL restore keeps dns_backup.json on disk for a manual retry,
+        so the DHCP reset must not fire in that case - it would destroy
+        whatever custom settings were about to be recovered."""
+        if not self.restore_dns_backup() and not os.path.exists(self.dns_backup_file):
+            self.revert_system_dns()
 
     def start_fetch(self):
         threading.Thread(target=self._prepare_and_fetch, daemon=True).start()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,9 @@ def make_gui():
     gui.is_exiting = False
     gui.is_initialized = True
     gui.base_path = REPO_ROOT
+    gui.sort_stack = []
+    gui.sort_dirs = {}
+    gui.settings = {}
 
     gui.block_ipv6_var = FakeVar(False)
     gui.require_dnssec_var = FakeVar(False)

--- a/tests/test_startup_and_settings.py
+++ b/tests/test_startup_and_settings.py
@@ -1,0 +1,145 @@
+"""Tests for autostart registration helpers, DNS backup policy and settings."""
+import json
+import os
+import platform
+import sys
+
+from conftest import make_gui
+
+
+class TestStartupTokens:
+    def test_script_mode_lists_interpreter_and_script(self, gui):
+        tokens = gui.get_startup_tokens()
+        assert tokens == [sys.executable, os.path.abspath(sys.argv[0])]
+
+    def test_frozen_mode_launches_executable_alone(self, gui, monkeypatch):
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        assert gui.get_startup_tokens() == [sys.executable]
+
+
+class TestQuotingHelpers:
+    def test_desktop_quote_escapes_specials(self, gui):
+        quoted = gui._desktop_quote('/home/u "my dir"')
+        assert quoted == '"/home/u \\"my dir\\""'
+
+    def test_desktop_quote_escapes_field_codes(self, gui):
+        assert gui._desktop_quote("app%U") == '"app%%U"'
+
+    def test_xml_escape(self, gui):
+        assert gui._xml_escape('a & b<c>') == "a &amp; b&lt;c&gt;"
+
+
+class TestRestorePolicy:
+    def _write_backup(self, path, platform_name="Windows"):
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump({"platform": platform_name}, fh)
+
+    def test_full_restore_deletes_backup(self, gui, tmp_path, monkeypatch):
+        backup = tmp_path / "dns_backup.json"
+        self._write_backup(str(backup))
+        gui.dns_backup_file = str(backup)
+        monkeypatch.setattr(gui.__class__, "_restore_dns_windows", lambda self, snap: [])
+        monkeypatch.setattr(platform, "system", lambda: "Windows")
+        assert gui.restore_dns_backup() is True
+        assert not backup.exists()
+
+    def test_partial_failure_keeps_backup_for_retry(self, gui, tmp_path, monkeypatch):
+        backup = tmp_path / "dns_backup.json"
+        self._write_backup(str(backup))
+        gui.dns_backup_file = str(backup)
+        monkeypatch.setattr(gui.__class__, "_restore_dns_windows",
+                            lambda self, snap: ["Ethernet"])
+        monkeypatch.setattr(platform, "system", lambda: "Windows")
+        assert gui.restore_dns_backup() is False
+        assert backup.exists(), "partial failure must keep the backup retryable"
+
+    def test_revert_helper_ignores_dhcp_reset_when_backup_remains(
+            self, gui, tmp_path, monkeypatch):
+        backup = tmp_path / "dns_backup.json"
+        self._write_backup(str(backup))
+        gui.dns_backup_file = str(backup)
+        monkeypatch.setattr(gui.__class__, "_restore_dns_windows",
+                            lambda self, snap: ["Ethernet"])
+        monkeypatch.setattr(platform, "system", lambda: "Windows")
+        reverted = []
+        monkeypatch.setattr(gui, "revert_system_dns", lambda: reverted.append(1))
+        gui._revert_after_restore_attempt()
+        assert reverted == [], "reset-to-DHCP must not fire while a retryable backup exists"
+        assert backup.exists()
+
+    def test_missing_backup_allows_last_resort_reset(self, gui, tmp_path, monkeypatch):
+        gui.dns_backup_file = str(tmp_path / "absent.json")
+        reverted = []
+        monkeypatch.setattr(gui, "revert_system_dns", lambda: reverted.append(1))
+        gui._revert_after_restore_attempt()
+        assert reverted == [1]
+
+    def test_wrong_platform_payload_is_ignored(self, gui, tmp_path, monkeypatch):
+        backup = tmp_path / "dns_backup.json"
+        self._write_backup(str(backup), platform_name="Darwin")
+        gui.dns_backup_file = str(backup)
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        called = []
+        monkeypatch.setattr(gui.__class__, "_restore_dns_linux",
+                            lambda self, snap: called.append(1) or [])
+        assert gui.restore_dns_backup() is False
+        assert not called, "payload for another OS must never be applied"
+
+
+class _FakeRoot:
+    def geometry(self):
+        return "1100x850+20+20"
+
+    def state(self):
+        return "normal"
+
+
+def make_gui_with_root(tmp_path):
+    """A gui whose persistence paths live in tmp and that has a fake root."""
+    gui = make_gui()
+    gui.root = _FakeRoot()
+    gui.settings_file = os.path.join(str(tmp_path), "settings.json")
+    gui.cache_file = os.path.join(str(tmp_path), "server_cache.json")
+    gui.dns_backup_file = os.path.join(str(tmp_path), "dns_backup.json")
+    return gui
+
+
+class TestSettingsRoundTrip:
+    def test_save_then_load_preserves_values(self, tmp_path):
+        gui = make_gui_with_root(tmp_path)
+        gui.block_ipv6_var.set(True)
+        gui.require_nolog_var.set(True)
+        gui.cache_size_var.set("1024")
+        gui.protocol_filter_var.set("DoH")
+        gui.config_dir_var.set("/tmp/cfg")
+        gui.proxy_path_var.set("/usr/bin/dnscrypt-proxy")
+        gui.server_relay_map = {"srv": ["relay"]}
+        gui.save_settings()
+        assert os.path.exists(gui.settings_file)
+
+        other = make_gui_with_root(tmp_path)
+        loaded = other.load_settings()
+        assert loaded["block_ipv6"] is True
+        assert loaded["require_nolog"] is True
+        assert loaded["cache_size"] == "1024"
+        assert loaded["ui_filter_protocol"] == "DoH"
+        assert loaded["config_dir"] == "/tmp/cfg"
+        assert loaded["proxy_executable_path"] == "/usr/bin/dnscrypt-proxy"
+        assert loaded["server_relay_map"] == {"srv": ["relay"]}
+        assert loaded["was_active"] is False
+
+    def test_deactivation_persists_empty_state(self, tmp_path):
+        gui = make_gui_with_root(tmp_path)
+        gui.preferred_servers = ["old-server"]
+        gui.save_settings()  # nothing active -> must record was_active=False
+        loaded = make_gui_with_root(tmp_path).load_settings()
+        assert loaded["was_active"] is False
+        assert loaded["last_active_servers"] == []
+
+    def test_corrupt_settings_fall_back_to_defaults(self, tmp_path):
+        gui = make_gui_with_root(tmp_path)
+        with open(gui.settings_file, "w") as fh:
+            fh.write("{not json")
+        defaults = gui.load_settings()
+        assert defaults["block_ipv6"] is False
+        assert defaults["cache_size"] == "512"


### PR DESCRIPTION
Follow-up to #6 (self-review pass, no new features):

## Autostart registration
- Frozen builds no longer register `"exe" "exe"` - the executable alone is registered.
- `.desktop` `Exec=` lines escape backslashes, quotes and percent field codes; plists XML-escape paths. Paths with spaces now work on every OS.

## Single-instance mutex
- Last-error read via `WinDLL(use_last_error=True)` + `ctypes.get_last_error()`; the previous `windll.GetLastError()` could observe a clobbered value and miss `ERROR_ALREADY_EXISTS`.

## Config-restart locking
- Acquire/release now happen on one thread; busy is reported instead of silently dropping configuration changes.

## Partial DNS restore policy
- A half-applied restore keeps `dns_backup.json` retryable and never triggers reset-to-DHCP; that fallback fires only when no backup remains (`_revert_after_restore_attempt` at all callers).

## CI
- Job timeouts (15/40/10 min) instead of 6-hour defaults.
- Dependabot now covers the `github-actions` ecosystem.

## Validation
42/42 tests (13 new), ruff bug-gate clean, GUI smoke OK, all workflow YAML valid.
