### PR TITLE
Production readiness: name dedupe, tray fallback, reactivation race

### DIFF
--- a/dnscrypt-proxy-gui.PY
+++ b/dnscrypt-proxy-gui.PY
@@ -201,6 +201,8 @@ class DNSCryptClientGUI:
         self.proxy_log_tail = collections.deque(maxlen=40)
         self._proxy_log_thread = None
         self._proxy_job_handle = None
+        self.tray_broken = False
+        self._auto_activation_started = False
         
         self.action_lock = threading.Lock() 
         self.tray_icon = None 
@@ -871,8 +873,8 @@ class DNSCryptClientGUI:
             if not os.path.exists(self.cache_file): return False
             with open(self.cache_file, 'r') as f:
                 data = json.load(f)
-                self.server_data = data.get("servers", [])
-                self.relay_data = data.get("relays", [])
+                self.server_data = self._dedupe_by_name(data.get("servers", []))
+                self.relay_data = self._dedupe_by_name(data.get("relays", []))
                 self.fetch_etags = data.get("etags", {})
                 self._server_by_name = {s["name"]: s for s in self.server_data}
                 self.server_cache_ts = data.get("timestamp")
@@ -881,13 +883,32 @@ class DNSCryptClientGUI:
             LOG.debug("Could not load server cache", exc_info=True)
             return False
 
+    @staticmethod
+    def _dedupe_by_name(items):
+        """Drop entries with missing or duplicated names, keeping the first.
+
+        Treeview rows and config static-sections are keyed by name, so a
+        duplicated entry from an upstream mirror or a corrupted cache would
+        raise TclError at populate time and break the whole server table."""
+        seen = set()
+        unique = []
+        for item in items:
+            name = item.get("name") if isinstance(item, dict) else None
+            if not name or name in seen:
+                LOG.warning("Dropping resolver entry with %s name: %r",
+                            "missing" if not name else "duplicate", name)
+                continue
+            seen.add(name)
+            unique.append(item)
+        return unique
+
     def setup_tray_and_close_protocol(self):
         self.root.protocol('WM_DELETE_WINDOW', self.on_close_window)
 
     def on_close_window(self):
-        if not TRAY_AVAILABLE:
-            # No tray icon exists, so closing must not silently strand the
-            # app as an unminimizable ghost - ask the user explicitly.
+        if not TRAY_AVAILABLE or getattr(self, "tray_broken", False):
+            # No working tray icon exists, so closing must not silently
+            # strand the app as an unminimizable ghost - ask explicitly.
             if messagebox.askyesno(
                     "Exit DNSCrypt Client?",
                     "The system tray icon is unavailable.\n"
@@ -933,9 +954,9 @@ class DNSCryptClientGUI:
             pass  # window destroyed - the loop dies with it
 
     def hide_window(self):
-        if not TRAY_AVAILABLE:
-            # No system-tray backend available - minimising keeps the app
-            # reachable instead of hiding it with no way back.
+        if not TRAY_AVAILABLE or getattr(self, "tray_broken", False):
+            # No working system-tray backend - minimising keeps the app
+            # reachable from the taskbar instead of hiding it.
             self.root.iconify()
             return
         self.root.withdraw()
@@ -946,10 +967,13 @@ class DNSCryptClientGUI:
                 with self.tray_lock: self.tray_icon = icon(APP_NAME, image, "DNSCrypt Client", menu)
                 self.tray_icon.run()
                 with self.tray_lock: self.tray_icon = None
-            except Exception as e:
-                print(f"Tray error: {e}")
-                LOG.error("Tray icon crashed", exc_info=True)
-                self.quit_app()
+            except Exception:
+                # Quitting here would silently deactivate a running proxy;
+                # degrade to taskbar mode and let the user stay in control.
+                LOG.error("Tray icon crashed - falling back to taskbar mode",
+                          exc_info=True)
+                self.tray_broken = True
+                self._post_ui(lambda: self.root.iconify())
 
         with self.tray_lock:
             if not (self.tray_thread and self.tray_thread.is_alive()):
@@ -1372,7 +1396,9 @@ class DNSCryptClientGUI:
                     if line:
                         self.proxy_log_tail.append(line.rstrip())
             except Exception:
-                pass
+                # A dead drain thread means diagnostics are incomplete;
+                # say so instead of reporting a misleading empty log.
+                LOG.debug("Proxy stderr drain stopped", exc_info=True)
             finally:
                 try:
                     proc.stderr.close()
@@ -1494,7 +1520,9 @@ class DNSCryptClientGUI:
                 if self.active_server_info:
                     self._revert_after_restore_attempt()
             except Exception:
-                pass
+                # The process is about to exit: this is the last chance to
+                # leave a trace of why DNS could not be restored.
+                LOG.error("Watchdog cleanup failed before exit", exc_info=True)
             _stop_proxy()
             os._exit(0)
 
@@ -1717,14 +1745,16 @@ class DNSCryptClientGUI:
 
             resp_res = conditional_get(RESOLVERS_URL, bool(self.server_data))
             if resp_res.status_code == 200:
-                self.server_data = self._parse_markdown_list(resp_res.text)
+                self.server_data = self._dedupe_by_name(
+                    self._parse_markdown_list(resp_res.text))
                 self.fetch_etags[RESOLVERS_URL] = resp_res.headers.get('ETag')
             elif resp_res.status_code != 304:
                 resp_res.raise_for_status()
 
             resp_rel = conditional_get(RELAYS_URL, bool(self.relay_data))
             if resp_rel.status_code == 200:
-                self.relay_data = self._parse_markdown_list(resp_rel.text)
+                self.relay_data = self._dedupe_by_name(
+                    self._parse_markdown_list(resp_rel.text))
                 self.fetch_etags[RELAYS_URL] = resp_rel.headers.get('ETag')
             elif resp_rel.status_code != 304:
                 resp_rel.raise_for_status()
@@ -1773,7 +1803,8 @@ class DNSCryptClientGUI:
         self.root.after(0, final_ui_update)
         
     def check_auto_activation(self):
-        if not self.preferred_servers: return
+        if not self.preferred_servers or self._auto_activation_started:
+            return
         servers_to_activate = [
             s for s in self.server_data if s["name"] in self.preferred_servers
         ]
@@ -1784,6 +1815,11 @@ class DNSCryptClientGUI:
         if wanted:
             self.tree.selection_set(wanted)
         if servers_to_activate:
+            # check_auto_activation runs both after cache load and after
+            # every fetch; without this flag the second invocation would
+            # queue a second worker that re-spawns the proxy once the
+            # first activation releases the lock.
+            self._auto_activation_started = True
             self.status_var.set(f"Automatically reactivating {len(servers_to_activate)} servers...")
             threading.Thread(target=lambda: self._activation_worker_direct(servers_to_activate), daemon=True).start()
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,8 @@ def make_gui():
     gui.sort_stack = []
     gui.sort_dirs = {}
     gui.settings = {}
+    gui.tray_broken = False
+    gui._auto_activation_started = False
 
     gui.block_ipv6_var = FakeVar(False)
     gui.require_dnssec_var = FakeVar(False)

--- a/tests/test_robustness.py
+++ b/tests/test_robustness.py
@@ -1,0 +1,93 @@
+"""Robustness regression tests: name dedupe and auto-activation guard."""
+import json
+import os
+import types
+
+from conftest import FakeVar, make_gui, mod
+
+
+class TestDedupeByName:
+    def test_duplicates_keep_first_occurrence(self, gui):
+        items = [{"name": "a", "stamp": "1"}, {"name": "a", "stamp": "2"}]
+        out = gui._dedupe_by_name(items)
+        assert [i["stamp"] for i in out] == ["1"]
+
+    def test_missing_or_empty_names_dropped(self, gui):
+        items = [{"stamp": "x"}, {"name": "", "stamp": "y"},
+                 {"name": "ok", "stamp": "z"}]
+        assert [i["name"] for i in gui._dedupe_by_name(items)] == ["ok"]
+
+    def test_non_dict_entries_dropped(self, gui):
+        assert gui._dedupe_by_name(["junk", 42, {"name": "ok"}]) == [{"name": "ok"}]
+
+    def test_unique_input_unchanged(self, gui):
+        items = [{"name": "a"}, {"name": "b"}]
+        assert gui._dedupe_by_name(items) == items
+
+    def test_cache_load_dedupes(self, tmp_path):
+        gui = make_gui()
+        gui.cache_file = os.path.join(str(tmp_path), "server_cache.json")
+        payload = {
+            "servers": [{"name": "dup", "stamp": "first"},
+                        {"name": "dup", "stamp": "second"}],
+            "relays": [],
+            "timestamp": 123.0,
+        }
+        with open(gui.cache_file, "w") as fh:
+            json.dump(payload, fh)
+        gui.load_server_cache()
+        assert len(gui.server_data) == 1
+        assert gui.server_data[0]["stamp"] == "first"
+        assert set(gui._server_by_name) == {"dup"}
+
+
+class TestAutoActivationGuard:
+    def _wired_gui(self, monkeypatch, rows=("a", "b")):
+        gui = make_gui()
+        gui.status_var = FakeVar("")
+        gui.tree = types.SimpleNamespace(
+            get_children=lambda *a: list(rows),
+            selection_set=lambda ids: None,
+        )
+        gui.server_data = [
+            {"name": "a", "stamp": "sdns://AQ", "proto_type": "DNSCrypt",
+             "no-log": "\u2713", "dnssec": "\u2713", "no-filter": "\u2713",
+             "description": ""},
+            {"name": "b", "stamp": "sdns://AQ", "proto_type": "DNSCrypt",
+             "no-log": "\u2713", "dnssec": "\u2713", "no-filter": "\u2713",
+             "description": ""},
+        ]
+        gui._server_by_name = {s["name"]: s for s in gui.server_data}
+        spawned = []
+
+        class FakeThread:
+            def __init__(self, target=None, daemon=None, **kwargs):
+                spawned.append(target)
+
+            def start(self):
+                pass
+
+        monkeypatch.setattr(mod.threading, "Thread", FakeThread)
+        return gui, spawned
+
+    def test_second_invocation_does_not_respawn(self, monkeypatch):
+        gui, spawned = self._wired_gui(monkeypatch)
+        gui.preferred_servers = ["a"]
+        gui.check_auto_activation()
+        gui.check_auto_activation()  # e.g. fetch completes after cache load
+        assert len(spawned) == 1
+
+    def test_no_match_does_not_block_later_success(self, monkeypatch):
+        gui, spawned = self._wired_gui(monkeypatch)
+        gui.preferred_servers = ["missing-server"]
+        gui.check_auto_activation()
+        gui.server_data.append({"name": "missing-server", "stamp": "sdns://AQ"})
+        gui._server_by_name["missing-server"] = gui.server_data[-1]
+        gui.check_auto_activation()
+        assert len(spawned) == 1
+
+    def test_no_preferences_is_noop(self, monkeypatch):
+        gui, spawned = self._wired_gui(monkeypatch)
+        gui.preferred_servers = []
+        gui.check_auto_activation()
+        assert spawned == []


### PR DESCRIPTION
Production-readiness follow-up to #6/#7, on top of v1.0.5. No new features.

## Duplicate resolver names no longer break the server table
Treeview rows and config static-sections are keyed by name, so a duplicated entry - from an upstream mirror glitch or a corrupted `server_cache.json` - raised `TclError` at populate time and left an unusable GUI until manual cache deletion. Entries with missing or duplicated names are now dropped (first occurrence wins) at **both** ingestion points: upstream fetch parsing and cache loading, with a warning logged for each.

## Tray crash no longer deactivates your proxy
When the tray thread failed, the app quit entirely - silently tearing down a running proxy and reverting DNS while the user believed protection was active. A tray failure now logs the error, sets a `tray_broken` flag and degrades to taskbar mode; closing the window then asks before exiting (same contract as the no-tray build).

## Auto-reactivation race
`check_auto_activation` runs both after cache load and after every fetch. When a refresh completed faster than the first activation, the second invocation queued another worker that re-spawned dnscrypt-proxy over a live process: port-bind failure, a dead `proxy_process` reference and a Deactivate button that could no longer stop the real proxy. Reactivation is now once-per-session.

## Diagnostics
Silent `except: pass` in the stderr drain thread and in the POSIX parent-watchdog cleanup replaced with logged traces (the watchdog log is flushed before exit).

## Validation
50/50 tests (8 new), ruff bug-gate clean, compile OK, headless GUI smoke test OK.
