### PR TITLE
Ingestion tolerance: malformed relay maps, duplicate relays, partial caches

### DIFF
--- a/dnscrypt-proxy-gui.PY
+++ b/dnscrypt-proxy-gui.PY
@@ -1144,13 +1144,27 @@ class DNSCryptClientGUI:
         for i, server in enumerate(filtered_list):
             relays = self.server_relay_map.get(server["name"], [])
             if isinstance(relays, str): relays = [relays] if relays else []
-            values = (server["name"], server.get('proto_type', '?'), ", ".join(relays), server["no-log"], server["dnssec"], server["no-filter"])
-            
+            if not isinstance(relays, list): relays = []
+            values = self._tree_values(server, ", ".join(relays))
+
             tag = 'oddrow' if i % 2 != 0 else 'evenrow'
             self.tree.insert("", tk.END, values=values, iid=server["name"], tags=(tag,))
-            
+
         self.status_var.set(f"Showing {len(filtered_list)} servers ({len(self.server_data)} total) and {len(self.relay_data)} relays.")
         self.apply_current_sorts()
+
+    @staticmethod
+    def _tree_values(server, relays_display):
+        """Row tuple for the server table.
+
+        Uses defaults for fields a cache file may predate, so a partial or
+        hand-edited cache can never raise KeyError at populate time."""
+        return (server["name"],
+                server.get("proto_type", "?"),
+                relays_display,
+                server.get("no-log", "\u2717"),
+                server.get("dnssec", "\u2717"),
+                server.get("no-filter", "\u2717"))
 
     def toggle_activation(self):
         if self.active_server_info:
@@ -1353,12 +1367,23 @@ class DNSCryptClientGUI:
             
             relay_list = self.server_relay_map.get(server_info['name'])
             if isinstance(relay_list, str): relay_list = [relay_list] if relay_list else []
-            
+            elif not isinstance(relay_list, list):
+                # Hand-edited or corrupted settings must not crash config
+                # generation - an unusable mapping is simply ignored.
+                LOG.warning("Ignoring malformed relay mapping for %r", server_info['name'])
+                relay_list = []
+
             if relay_list and server_info['stamp'].startswith("sdns://AQ"):
                 # Drop mappings whose relay has vanished from the upstream
                 # list - emitting a route without a matching [static] stamp
                 # would make dnscrypt-proxy exit immediately.
-                valid_relays = [r for r in relay_list if r in known_relay_stamps]
+                seen_relays = set()
+                valid_relays = []
+                for r in relay_list:
+                    if (isinstance(r, str) and r in known_relay_stamps
+                            and r not in seen_relays):
+                        seen_relays.add(r)
+                        valid_relays.append(r)
                 if not valid_relays: continue
                 safe_relays = []
                 for r_name in valid_relays:
@@ -1845,9 +1870,10 @@ class DNSCryptClientGUI:
             s = self._server_by_name.get(focused_id)
             if s:
                 relay_list = self.server_relay_map.get(s["name"], [])
-                relay_info = ", ".join(relay_list if isinstance(relay_list, list) else [relay_list]) or "None"
+                if not isinstance(relay_list, list): relay_list = [relay_list] if relay_list else []
+                relay_info = ", ".join(relay_list) or "None"
                 details = (f"Name: {s['name']}\nProtocol: {s.get('proto_type', 'Unknown')}\nVia Bridge: {relay_info}\n"
-                           f"Desc: {s['description']}\nProps: {s['properties']}\n\nSTAMP:\n{s['stamp']}")
+                           f"Desc: {s.get('description', '')}\nProps: {s.get('properties', '')}\n\nSTAMP:\n{s.get('stamp', 'unknown')}")
                 self.details_text.configure(state='normal'); self.details_text.delete(1.0, tk.END)
                 self.details_text.insert(tk.END, details); self.details_text.configure(state='disabled')
 

--- a/tests/test_config_generation.py
+++ b/tests/test_config_generation.py
@@ -1,6 +1,10 @@
 """Tests for dnscrypt-proxy.toml generation and sanitisation logic."""
 import tomllib
 
+import pytest
+
+from conftest import mod
+
 
 class TestCleanServerName:
     def test_strips_invalid_characters(self, gui):
@@ -175,3 +179,44 @@ class TestStaleRelayRegression:
         for route in routes:
             for via in route["via"]:
                 assert via in static_keys, f"dangling relay '{via}'"
+
+class TestMalformedRelayMappings:
+    """Hand-edited or corrupted settings must never crash generation."""
+
+    def _generate(self, gui, sample_servers, relay_map):
+        gui.server_relay_map = relay_map
+        gui.relay_data = [{"name": "relay-one", "stamp": "sdns://AQRRRUxBWSAAAAA="}]
+        return tomllib.loads(gui._generate_config_content(sample_servers))
+
+    @pytest.mark.parametrize("bad_value", [5, {"a": 1}, None, True, [["nested"]]])
+    def test_garbage_mapping_types_are_ignored(self, gui, sample_servers, bad_value):
+        parsed = self._generate(gui, sample_servers, {"example-a": bad_value})
+        assert parsed.get("anonymized_dns", {}).get("routes", []) == []
+
+    def test_duplicate_relays_in_one_mapping_deduped(self, gui, sample_servers):
+        parsed = self._generate(gui, sample_servers, {"example-a": ["relay-one", "relay-one"]})
+        routes = parsed["anonymized_dns"]["routes"]
+        assert len(routes) == 1
+        assert routes[0]["via"] == ["relayone"]
+
+    def test_non_string_entries_within_list_skipped(self, gui, sample_servers):
+        parsed = self._generate(gui, sample_servers, {"example-a": ["relay-one", 7]})
+        assert parsed["anonymized_dns"]["routes"][0]["via"] == ["relayone"]
+
+    def test_valid_string_shorthand_still_works(self, gui, sample_servers):
+        parsed = self._generate(gui, sample_servers, {"example-a": "relay-one"})
+        assert parsed["anonymized_dns"]["routes"][0]["via"] == ["relayone"]
+
+
+class TestTreeValuesDefaults:
+    def test_missing_optional_fields_get_defaults(self):
+        values = mod.DNSCryptClientGUI._tree_values({"name": "x"}, "")
+        assert values[0] == "x"
+        assert values[1] == "?"
+        assert values[3:] == ("\u2717", "\u2717", "\u2717")
+
+    def test_present_fields_preserved(self):
+        server = {"name": "x", "proto_type": "DoH",
+                  "no-log": "\u2713", "dnssec": "\u2713", "no-filter": "\u2717"}
+        values = mod.DNSCryptClientGUI._tree_values(server, "via-relay")
+        assert values == ("x", "DoH", "via-relay", "\u2713", "\u2713", "\u2717")


### PR DESCRIPTION
Ingestion-tolerance hardening, follow-up to #6/#7/#16. No new features.

## Malformed relay mappings
`server_relay_map` values that were not a string or list (e.g. a number or object from hand-edited settings) crashed `_generate_config_content` with `TypeError` mid-write. Non-list mappings are now ignored with a logged warning; string shorthand still works.

## Duplicate relays within one mapping
Mapping a server to the same relay twice produced duplicated `via` entries in the generated TOML. De-duplicated while preserving order.

## Partial cache entries
The server table indexed `no-log` / `dnssec` / `no-filter` directly and the details pane indexed `description` / `properties` / `stamp`, so a cache file predating any of those fields raised `KeyError` at populate time. Row building now goes through `_tree_values()` with sensible defaults, and the details pane uses `.get()` fallbacks.

## Validation
60/60 tests (10 new: parametrized garbage-mapping types, duplicate relay dedupe, non-string list entries, string shorthand regression, tree-value defaults), ruff bug-gate clean, compile OK, headless GUI smoke OK.
