### PR TITLE
Fix: config changes during an active session never restarted the proxy

### DIFF
--- a/dnscrypt-proxy-gui.PY
+++ b/dnscrypt-proxy-gui.PY
@@ -913,7 +913,7 @@ class DNSCryptClientGUI:
                     "Exit DNSCrypt Client?",
                     "The system tray icon is unavailable.\n"
                     "Closing this window will EXIT the application\n"
-                    "(and deactivate the proxy). Continue?"):
+                    "(and deactivate the proxy). Continue?", parent=self.root):
                 self.quit_app()
             else:
                 self.root.iconify()
@@ -1652,6 +1652,11 @@ class DNSCryptClientGUI:
         self.root.after(0, lambda: self.status_var.set("Deactivating..."))
         self.root.after(0, lambda: self.activate_button.config(state=tk.DISABLED))
 
+        # Authoritative state flips synchronously: callers on worker threads
+        # (e.g. the config-restart flow) check this flag immediately after
+        # this method returns, long before the queued UI reset runs.
+        self.active_server_info = []
+
         if self.proxy_process:
             self.proxy_process.terminate()
             try:
@@ -1663,15 +1668,14 @@ class DNSCryptClientGUI:
         # Exact restoration of the user's previous DNS configuration; the
         # reset-to-DHCP path is only a last resort when no backup exists.
         self._revert_after_restore_attempt()
-        
+
         def final_ui_reset():
-            self.active_server_info = []
             self.activate_button.config(text="Activate Selected Server(s)", state=tk.NORMAL if self.tree.selection() else tk.DISABLED)
             self.status_indicator.config(text="STATUS: INACTIVE", style="Inactive.TLabel")
             self.active_server_label.config(text="No server active.")
             self.status_var.set("Deactivated. System DNS restored.")
             self.save_settings()
-        
+
         self.root.after(0, final_ui_reset)
 
     def set_system_dns(self, dns_server):

--- a/tests/test_robustness.py
+++ b/tests/test_robustness.py
@@ -1,4 +1,4 @@
-"""Robustness regression tests: name dedupe and auto-activation guard."""
+﻿"""Robustness regression tests: name dedupe and auto-activation guard."""
 import json
 import os
 import types
@@ -91,3 +91,57 @@ class TestAutoActivationGuard:
         gui.preferred_servers = []
         gui.check_auto_activation()
         assert spawned == []
+
+class TestDeactivateStateContract:
+    """update_config_and_restart_proxy checks active_server_info right
+    after deactivate_dns returns on a worker thread; the clear must
+    therefore happen synchronously, not in the queued UI reset."""
+
+    class _InlineRoot:
+        def after(self, ms, fn=None):
+            if fn:
+                fn()
+
+    @staticmethod
+    def _widget():
+        return types.SimpleNamespace(config=lambda **k: None)
+
+    def test_state_clears_before_queued_ui_reset(self, gui, monkeypatch):
+        gui.root = self._InlineRoot()
+        gui.activate_button = self._widget()
+        gui.status_indicator = self._widget()
+        gui.active_server_label = self._widget()
+        gui.status_var = FakeVar("")
+        gui.tree = types.SimpleNamespace(selection=lambda: [])
+        gui.proxy_process = None
+        gui.dns_backup_file = os.path.join("does", "not", "exist.json")
+        gui.save_settings = lambda: None
+        gui.active_server_info = [{"name": "a"}]
+        monkeypatch.setattr(gui.__class__, "_revert_after_restore_attempt",
+                            lambda self: None)
+        gui.deactivate_dns()
+        assert gui.active_server_info == [], (
+            "restart flow must observe the cleared state immediately")
+
+    def test_restart_flow_would_reactivate(self, gui, monkeypatch):
+        """Replicates the update_config_and_restart_proxy decision."""
+        gui.root = self._InlineRoot()
+        gui.activate_button = self._widget()
+        gui.status_indicator = self._widget()
+        gui.active_server_label = self._widget()
+        gui.status_var = FakeVar("")
+        gui.tree = types.SimpleNamespace(selection=lambda: [])
+        gui.proxy_process = None
+        gui.dns_backup_file = os.path.join("does", "not", "exist.json")
+        gui.save_settings = lambda: None
+        gui.active_server_info = [{"name": "a"}]
+        monkeypatch.setattr(gui.__class__, "_revert_after_restore_attempt",
+                            lambda self: None)
+        reactivated = []
+        monkeypatch.setattr(gui, "activate_dns",
+                            lambda servers: reactivated.append(servers))
+        current_servers = gui.active_server_info
+        gui.deactivate_dns()
+        if not gui.active_server_info:
+            gui.activate_dns(current_servers)
+        assert reactivated == [current_servers]


### PR DESCRIPTION
Fixes a core-flow bug found in the ongoing self-review; no new features.

## "Instant Apply" never actually restarted the proxy

`update_config_and_restart_proxy` (wired to every config checkbox, cache field and path change while active) calls `deactivate_dns()` on its worker thread, then checks `active_server_info` to decide whether to re-activate. That flag was only cleared inside the **deferred** UI reset (`root.after(0, final_ui_reset)`), so the worker's synchronous check always saw the stale list - `activate_dns` was skipped and changes silently failed to apply until a manual deactivate/reactivate.

`deactivate_dns` now flips `active_server_info` synchronously at entry; widget updates remain in the deferred reset. Two regression tests pin the contract (synchronous clear + restart-flow decision).

Also: the tray-less exit-confirm dialog gets an explicit parent window.

## Validation
62/62 tests (+2), ruff bug-gate clean, compile OK, headless GUI smoke OK.
